### PR TITLE
Clarify system handedness

### DIFF
--- a/files/en-us/web/api/webgl_api/matrix_math_for_the_web/index.html
+++ b/files/en-us/web/api/webgl_api/matrix_math_for_the_web/index.html
@@ -240,7 +240,7 @@ let transformedPoint = [
 ];
 </pre>
 
-<p>It is possible to encode these type of steps into a matrix, and do it for each of the x, y, and z dimensions. Below is the representation of a rotation about the X axis:</p>
+<p>It is possible to encode these type of steps into a matrix, and do it for each of the x, y, and z dimensions. Below is the representation of a counterclowise rotation about the Z axis in a left-handed coordinate system:</p>
 
 <pre class="brush: js notranslate">let sin = Math.sin;
 let cos = Math.cos;


### PR DESCRIPTION
The clarification of the system handedness is useful to correctly interpreter the orientation of the rotation. The handedness is consistent with CSS conventions, as shown in the fiddle example.